### PR TITLE
演習1 一覧表示と詳細表示

### DIFF
--- a/src/main/java/com/example/exintermediate/controller/TeamController.java
+++ b/src/main/java/com/example/exintermediate/controller/TeamController.java
@@ -1,7 +1,6 @@
 package com.example.exintermediate.controller;
 
 import java.util.List;
-import java.util.ArrayList;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -12,6 +11,9 @@ import com.example.exintermediate.domain.Team;
 import com.example.exintermediate.service.TeamService;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
 
 @Controller
 @RequestMapping("/team")
@@ -24,7 +26,16 @@ public class TeamController {
   public String index(Model model) {
     List<Team> team_list = service.findAll();
     model.addAttribute("team_list", team_list);
-    
+
     return "team/index";
   }
+
+  @GetMapping("/show/{id}")
+  public String show(Model model, @PathVariable("id") Integer id) {
+    Team team = service.load(id);
+    model.addAttribute("team", team);
+
+    return "team/show";
+  }
+  
 }

--- a/src/main/java/com/example/exintermediate/controller/TeamController.java
+++ b/src/main/java/com/example/exintermediate/controller/TeamController.java
@@ -1,0 +1,30 @@
+package com.example.exintermediate.controller;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.exintermediate.domain.Team;
+import com.example.exintermediate.service.TeamService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequestMapping("/team")
+public class TeamController {
+
+  @Autowired
+  private TeamService service;
+
+  @GetMapping({"","/"})
+  public String index(Model model) {
+    List<Team> team_list = service.findAll();
+    model.addAttribute("team_list", team_list);
+    
+    return "team/index";
+  }
+}

--- a/src/main/java/com/example/exintermediate/domain/Team.java
+++ b/src/main/java/com/example/exintermediate/domain/Team.java
@@ -1,0 +1,58 @@
+package com.example.exintermediate.domain;
+
+public class Team {
+  /** ID */
+  private int id;
+  /** リーグ名 */
+  private String leagueName;
+  /** チーム名 */
+  private String teamName;
+  /** ホーム */
+  private String headquarters;
+  /** 創立 */
+  private String inauguration;
+  /** 歴史 */
+  private String history;
+  public int getId() {
+    return id;
+  }
+  public void setId(int id) {
+    this.id = id;
+  }
+  public String getLeagueName() {
+    return leagueName;
+  }
+  public void setLeagueName(String leagueName) {
+    this.leagueName = leagueName;
+  }
+  public String getTeamName() {
+    return teamName;
+  }
+  public void setTeamName(String teamName) {
+    this.teamName = teamName;
+  }
+  public String getHeadquarters() {
+    return headquarters;
+  }
+  public void setHeadquarters(String headquarters) {
+    this.headquarters = headquarters;
+  }
+  public String getInauguration() {
+    return inauguration;
+  }
+  public void setInauguration(String inauguration) {
+    this.inauguration = inauguration;
+  }
+  public String getHistory() {
+    return history;
+  }
+  public void setHistory(String history) {
+    this.history = history;
+  }
+  @Override
+  public String toString() {
+    return "Team [id=" + id + ", leagueName=" + leagueName + ", teamName=" + teamName + ", headquarters=" + headquarters
+        + ", inauguration=" + inauguration + ", history=" + history + "]";
+  }
+  
+}

--- a/src/main/java/com/example/exintermediate/repository/TeamRepository.java
+++ b/src/main/java/com/example/exintermediate/repository/TeamRepository.java
@@ -20,6 +20,11 @@ public class TeamRepository {
       FROM teams
         ORDER BY inauguration ASC;   
   """;
+  private static final String LOAD_SQL = """
+    SELECT id, league_name, team_name, headquarters, inauguration, history
+      FROM teams
+        WHERE id = :id;  
+  """;
   private static final RowMapper<Team> TEAM_ROW_MAPPER = (rs,i) -> {
     Team team = new Team();
     team.setId(rs.getInt("id"));
@@ -39,5 +44,15 @@ public class TeamRepository {
   public List<Team> findAll(){
     SqlParameterSource param = new MapSqlParameterSource();
     return template.query(FIND_ALL_QUERY, param, TEAM_ROW_MAPPER);
+  }
+
+  /**
+   * 引数に指定したチームのidをもとに、該当のチーム情報を取得して返却する.
+   * @param id
+   * @return Team チームオブジェクト
+   */
+  public Team Load(int id){
+    SqlParameterSource param = new MapSqlParameterSource().addValue("id", id);
+    return template.queryForObject(LOAD_SQL, param, TEAM_ROW_MAPPER);
   }
 }

--- a/src/main/java/com/example/exintermediate/repository/TeamRepository.java
+++ b/src/main/java/com/example/exintermediate/repository/TeamRepository.java
@@ -1,0 +1,43 @@
+package com.example.exintermediate.repository;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import com.example.exintermediate.domain.Team;
+
+@Repository
+public class TeamRepository {
+  @Autowired
+  private NamedParameterJdbcTemplate template;
+  private static final String FIND_ALL_QUERY = """
+    SELECT id, league_name, team_name, headquarters, inauguration, history
+      FROM teams
+        ORDER BY inauguration ASC;   
+  """;
+  private static final RowMapper<Team> TEAM_ROW_MAPPER = (rs,i) -> {
+    Team team = new Team();
+    team.setId(rs.getInt("id"));
+    team.setLeagueName(rs.getString("league_name"));
+    team.setTeamName(rs.getString("team_name"));
+    team.setHeadquarters(rs.getString("headquarters"));
+    team.setInauguration(rs.getString("inauguration"));
+    team.setHistory(rs.getString("history"));
+    return team;
+  };
+
+  /**
+   * 全チームの情報をDBから取得して発足日の昇順のリストを返却する.
+   * 
+   * @return List<Team> チームオブジェクトのリスト
+   */
+  public List<Team> findAll(){
+    SqlParameterSource param = new MapSqlParameterSource();
+    return template.query(FIND_ALL_QUERY, param, TEAM_ROW_MAPPER);
+  }
+}

--- a/src/main/java/com/example/exintermediate/service/TeamService.java
+++ b/src/main/java/com/example/exintermediate/service/TeamService.java
@@ -1,0 +1,24 @@
+package com.example.exintermediate.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.exintermediate.domain.Team;
+import com.example.exintermediate.repository.TeamRepository;
+
+@Service
+public class TeamService {
+  @Autowired
+  private TeamRepository repository;
+
+  /**
+   * 全チームのリストを取得して返す.
+   * 
+   * @return
+   */
+  public List<Team> findAll(){
+    return repository.findAll();
+  }
+}

--- a/src/main/java/com/example/exintermediate/service/TeamService.java
+++ b/src/main/java/com/example/exintermediate/service/TeamService.java
@@ -21,4 +21,14 @@ public class TeamService {
   public List<Team> findAll(){
     return repository.findAll();
   }
+
+  /**
+   * 該当のチーム情報を取得して返す.
+   * 
+   * @param id
+   * @return Team チームオブジェクト
+   */
+  public Team load(int id){
+    return repository.Load(id);
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driverClassName: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/student
+    url: jdbc:postgresql://localhost:5432/ex_intermediate
     username: postgres
     password: postgres
 server:

--- a/src/main/resources/templates/team/index.html
+++ b/src/main/resources/templates/team/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <h2>野球チーム一覧</h2>
+  <ul th:each="team : ${team_list}">
+    <li><a href="#" th:text="${team.teamName}">team_name</a></li>
+  </ul>
+</body>
+</html>

--- a/src/main/resources/templates/team/index.html
+++ b/src/main/resources/templates/team/index.html
@@ -8,7 +8,7 @@
 <body>
   <h2>野球チーム一覧</h2>
   <ul th:each="team : ${team_list}">
-    <li><a href="#" th:text="${team.teamName}">team_name</a></li>
+    <li style="list-style: none;"><a th:href="@{/team/show/{id}(id=${team.id})}" th:text="${team.teamName}">team_name</a></li>
   </ul>
 </body>
 </html>

--- a/src/main/resources/templates/team/show.html
+++ b/src/main/resources/templates/team/show.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <div th:object="${team}">
+
+    <h3>球団名</h3>
+    <p th:text="*{teamName}">team_name</p>
+    <h3>本拠地</h3>
+    <p th:text="*{headquarters}">headquarters</p>
+    <h3>発足</h3>
+    <p th:text="*{inauguration}">inauguration</p>
+    <h3>歴史</h3>
+    <p th:text="*{history}">history</p>
+
+    <a th:href="@{/team/}">戻る</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 対応する課題
- Ex1

## やったこと
- チーム一覧表示機能の実装
- チーム詳細表示機能の実装

## 動作確認
- `localhost:8080/ex-intermediate/team/`にアクセスすると一覧画面が表示され、DBに存在する全チームの名前が創立年の昇順で表示されている
- `localhost:8080/ex-intermediate/team/show/{team_id}`にアクセスすると、パラメータに指定したidに該当するチームの詳細情報画面が表示される

## その他

